### PR TITLE
Updated MonthKey

### DIFF
--- a/Instructions/Labs/da-100-06a_instructions.md
+++ b/Instructions/Labs/da-100-06a_instructions.md
@@ -201,7 +201,7 @@ In this task, you will add additional columns to enable filtering and grouping b
 	```
 	MonthKey =
 
-	(YEAR('Date'[Date]) * 100) + MONTH('Date'[Date]) + MONTH ( [Date] ))
+	(YEAR('Date'[Date]) * 100) + MONTH('Date'[Date])
 	```
 
 	*This formula computes a numeric value for each year/month combination*.


### PR DESCRIPTION
MonthKey doesn't work and differs from the formula in the snippet. 

# Module: 6
## Lab/Demo: 6a

Fixes # .
Should be: MonthKey = (YEAR('Date'[Date]) * 100) + MONTH('Date'[Date])

Changes proposed in this pull request:

-
-
-